### PR TITLE
Add zip to prerequisites and make shell scripts fail on errors

### DIFF
--- a/cloudify_marketplace/README.md
+++ b/cloudify_marketplace/README.md
@@ -1,8 +1,10 @@
 # Cloudify AMI builder
 
 ## Prerequisites
+> A UNIX-like OS is required for running Packer. Builds aren't supported on Windows
 
 * [packer](https://www.packer.io/intro/getting-started/setup.html) (tested on 0.8.6)
+* zip
 * Account credentials for each cloud platform you want to build on.
 * An image ID to base the new image on.
 * OpenStack specific:

--- a/cloudify_marketplace/provision/bootstrap_simple
+++ b/cloudify_marketplace/provision/bootstrap_simple
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 function install_prereqs
 {

--- a/cloudify_marketplace/provision/cleanup
+++ b/cloudify_marketplace/provision/cleanup
@@ -1,4 +1,5 @@
 #!/bin/bash -e
+set -e
 
 # Clean up folders we used
 if [[ "${PERFORM_CLEANUP}" == "true" ]]; then

--- a/cloudify_marketplace/provision/enable_systemd_service
+++ b/cloudify_marketplace/provision/enable_systemd_service
@@ -1,4 +1,6 @@
 #! /usr/bin/env bash
+set -e
+
 DEST=/etc/systemd/system/${SERVICE_NAME}
 sudo mv /tmp/${SERVICE_NAME} ${DEST}
 sudo chown root. ${DEST}

--- a/cloudify_marketplace/provision/enable_usr_local_script
+++ b/cloudify_marketplace/provision/enable_usr_local_script
@@ -1,4 +1,6 @@
 #! /usr/bin/env bash
+set -e
+
 DEST=/usr/local/bin/${SCRIPT_NAME}
 sudo mv /tmp/${SCRIPT_NAME} ${DEST}
 sudo chown root. ${DEST}

--- a/cloudify_marketplace/provision/install_dependencies
+++ b/cloudify_marketplace/provision/install_dependencies
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+set -e
 
 # Install the appropriate dependencies into the mgmtworker env
 if [[ -f /tmp/dependencies/${PACKER_BUILD_NAME}_dependencies.zip ]]; then

--- a/cloudify_marketplace/provision/os_configure
+++ b/cloudify_marketplace/provision/os_configure
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # disable selinux
 sudo setenforce 0

--- a/cloudify_marketplace/provision/security_reconfiguration_setup
+++ b/cloudify_marketplace/provision/security_reconfiguration_setup
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+set -e
 
 if [[ "${CLOUDIFY_MANAGER_SECURITY_ENABLED}" == "true" ]]; then
   # Security enabled, activate the cron job

--- a/cloudify_marketplace/provision/upload_blueprint
+++ b/cloudify_marketplace/provision/upload_blueprint
@@ -1,4 +1,6 @@
 #! /usr/bin/env bash
+set -e 
+
 CFY_BIN=/opt/cfy_cli/bin/cfy
 cd ${BLUEPRINT_PATH}
 

--- a/cloudify_marketplace/provision_local/make_dependencies
+++ b/cloudify_marketplace/provision_local/make_dependencies
@@ -1,4 +1,6 @@
 #! /usr/bin/env bash
+set -e
+
 for platform in $(ls dependencies); do
   mkdir ${platform}_dependencies
   cp dependencies/${platform} ${platform}_dependencies/setup.py

--- a/cloudify_marketplace/resources/fix_cloudify_ip_configurations
+++ b/cloudify_marketplace/resources/fix_cloudify_ip_configurations
@@ -1,4 +1,6 @@
 #! /usr/bin/env bash
+set -e
+
 ip=$(get_first_external_ip)
 
 /usr/bin/sed -i -e "s/MANAGEMENT_IP=.*/MANAGEMENT_IP="'"'"${ip}"'"'"/" /etc/sysconfig/cloudify-mgmtworker

--- a/cloudify_marketplace/resources/get_first_external_ip
+++ b/cloudify_marketplace/resources/get_first_external_ip
@@ -1,2 +1,4 @@
 #! /usr/bin/env bash
+set -e
+
 /usr/sbin/ip a s | /usr/bin/grep -oE 'inet [^/]+' | /usr/bin/cut -d' ' -f2 | /usr/bin/grep -v '^127.' | /usr/bin/grep -v '^169.254.' | /usr/bin/head -n1


### PR DESCRIPTION
This failed on the build box because zip wasn't present. the `set -e` means issues like this in future should be detected during the build instead of when trying to deploy an image
